### PR TITLE
Add link to mailing list

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,7 +43,7 @@
         
         
   <div class="contentTitle"><h1>Join the Team </h1></div>
-        <div class="contentText">If you want to join the team, please contact w5nyv at yahoo dot com.
+        <div class="contentText">If you want to join the team, please <a href="https://lists.openresearch.institute/mailman/listinfo/ground-station">subscribe to the Ground-Station mailing list</a>, hosted by the Open Research Institute.
         </div>
         
         


### PR DESCRIPTION
Hi there -- while posting to the SatNOGS forum about the Phase 4 Ground project, I realized that the web page did not mention the mailing list.  This PR adds a link to the index page. Things I'm not sure about:

- Do you want to add links to the Open Research Institute website? ("Regular updates can be found at...")
- Do you want to mention the Slack channel?

Thanks, and please let me know if you need any further info.